### PR TITLE
Changing isset to array_key_exists to address null options as in #5

### DIFF
--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -171,11 +171,11 @@ class ReCaptcha extends AbstractAdapter
     public function setOption($key, $value)
     {
         $service = $this->getService();
-        if (array_key_exists($this->serviceParams[$key])) {
+        if (array_key_exists($key, $this->serviceParams)) {
             $service->setParam($key, $value);
             return $this;
         }
-        if (array_key_exists($this->serviceOptions[$key])) {
+        if (array_key_exists($key, $this->serviceOptions)) {
             $service->setOption($key, $value);
             return $this;
         }

--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -171,11 +171,11 @@ class ReCaptcha extends AbstractAdapter
     public function setOption($key, $value)
     {
         $service = $this->getService();
-        if (isset($this->serviceParams[$key])) {
+        if (array_key_exists($this->serviceParams[$key])) {
             $service->setParam($key, $value);
             return $this;
         }
-        if (isset($this->serviceOptions[$key])) {
+        if (array_key_exists($this->serviceOptions[$key])) {
             $service->setOption($key, $value);
             return $this;
         }

--- a/test/ReCaptchaTest.php
+++ b/test/ReCaptchaTest.php
@@ -45,6 +45,8 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
             'pubKey'  => 'publicKey',
             'ssl'     => true,
             'xhtml'   => true,
+            'lang'    => null,
+            'theme'   => 'red',
         ];
         $captcha = new ReCaptcha($options);
         $test    = $captcha->getOptions();
@@ -58,6 +60,10 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
             $this->assertArrayHasKey($key, $test);
             $this->assertSame($value, $test[$key]);
         }
+
+        $test = $service->getOptions();
+        $compare = ['lang' => $options['lang'], 'theme' => $options['theme']];
+        $this->assertEquals($compare, $test);
     }
 
     public function testShouldAllowSpecifyingServiceObject()


### PR DESCRIPTION
For instance, the 'lang' option is null per default (auto-detect), so you can never set it through constructor because of the isset check. Changing to array_key_exists solves this problem.
