### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-math": "~2.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-math": "^2.6",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-session": "~2.5",
-        "zendframework/zend-text": "~2.5",
-        "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-session": "^2.6",
+        "zendframework/zend-text": "^2.6",
+        "zendframework/zend-validator": "^2.6",
         "zendframework/zendservice-recaptcha": "*",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"


### PR DESCRIPTION
Update dependencies to known-stable, forwards-compatible versions, and require PHP 7 builds to succeed.
