### PR TITLE
Feature/docblock method chaining consistency

### DIFF
--- a/src/AbstractAdapter.php
+++ b/src/AbstractAdapter.php
@@ -18,6 +18,7 @@ use Zend\Validator\AbstractValidator;
  * Provides some utility functionality to build on
  */
 abstract class AbstractAdapter extends AbstractValidator implements AdapterInterface
+
 {
     /**
      * Captcha name
@@ -58,7 +59,7 @@ abstract class AbstractAdapter extends AbstractValidator implements AdapterInter
      * Set name
      *
      * @param string $name
-     * @return AbstractAdapter
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setName($name)
     {
@@ -71,7 +72,7 @@ abstract class AbstractAdapter extends AbstractValidator implements AdapterInter
      *
      * @param  string $key
      * @param  string $value
-     * @return AbstractAdapter
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setOption($key, $value)
     {
@@ -97,7 +98,7 @@ abstract class AbstractAdapter extends AbstractValidator implements AdapterInter
      *
      * @param  array|Traversable $options
      * @throws Exception\InvalidArgumentException
-     * @return AbstractAdapter
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setOptions($options = [])
     {

--- a/src/AbstractWord.php
+++ b/src/AbstractWord.php
@@ -125,7 +125,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Set session class for persistence
      *
      * @param  string $sessionClass
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     public function setSessionClass($sessionClass)
     {
@@ -147,7 +147,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Set word length of captcha
      *
      * @param int $wordlen
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     public function setWordlen($wordlen)
     {
@@ -172,7 +172,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Set captcha identifier
      *
      * @param string $id
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     protected function setId($id)
     {
@@ -184,7 +184,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Set timeout for session token
      *
      * @param  int $ttl
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     public function setTimeout($ttl)
     {
@@ -206,7 +206,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Sets if session should be preserved on generate()
      *
      * @param bool $keepSession Should session be kept on generate()?
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     public function setKeepSession($keepSession)
     {
@@ -228,7 +228,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Set if numbers should be included in the pattern
      *
      * @param  bool $useNumbers numbers should be included in the pattern?
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     public function setUseNumbers($useNumbers)
     {
@@ -260,7 +260,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Set session namespace object
      *
      * @param  Container $session
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     public function setSession(Container $session)
     {
@@ -289,7 +289,7 @@ abstract class AbstractWord extends AbstractAdapter
      * Set captcha word
      *
      * @param  string $word
-     * @return AbstractWord
+     * @return AbstractWord Provides a fluent interface
      */
     protected function setWord($word)
     {

--- a/src/Image.php
+++ b/src/Image.php
@@ -260,7 +260,7 @@ class Image extends AbstractWord
 
     /**
      * @param string $startImage
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setStartImage($startImage)
     {
@@ -270,7 +270,7 @@ class Image extends AbstractWord
 
     /**
      * @param int $dotNoiseLevel
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setDotNoiseLevel($dotNoiseLevel)
     {
@@ -280,7 +280,7 @@ class Image extends AbstractWord
 
     /**
      * @param int $lineNoiseLevel
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setLineNoiseLevel($lineNoiseLevel)
     {
@@ -292,7 +292,7 @@ class Image extends AbstractWord
      * Set captcha expiration
      *
      * @param  int $expiration
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setExpiration($expiration)
     {
@@ -304,7 +304,7 @@ class Image extends AbstractWord
      * Set garbage collection frequency
      *
      * @param  int $gcFreq
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setGcFreq($gcFreq)
     {
@@ -316,7 +316,7 @@ class Image extends AbstractWord
      * Set captcha font
      *
      * @param  string $font
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setFont($font)
     {
@@ -328,7 +328,7 @@ class Image extends AbstractWord
      * Set captcha font size
      *
      * @param  int $fsize
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setFontSize($fsize)
     {
@@ -340,7 +340,7 @@ class Image extends AbstractWord
      * Set captcha image height
      *
      * @param  int $height
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setHeight($height)
     {
@@ -352,7 +352,7 @@ class Image extends AbstractWord
      * Set captcha image storage directory
      *
      * @param  string $imgDir
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setImgDir($imgDir)
     {
@@ -364,7 +364,7 @@ class Image extends AbstractWord
      * Set captcha image base URL
      *
      * @param  string $imgUrl
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setImgUrl($imgUrl)
     {
@@ -374,7 +374,7 @@ class Image extends AbstractWord
 
     /**
      * @param string $imgAlt
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setImgAlt($imgAlt)
     {
@@ -386,7 +386,7 @@ class Image extends AbstractWord
      * Set captcha image filename suffix
      *
      * @param  string $suffix
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setSuffix($suffix)
     {
@@ -398,7 +398,7 @@ class Image extends AbstractWord
      * Set captcha image width
      *
      * @param  int $width
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setWidth($width)
     {

--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -84,7 +84,7 @@ class ReCaptcha extends AbstractAdapter
      * Set ReCaptcha private key
      *
      * @param  string $secretKey
-     * @return ReCaptcha
+     * @return ReCaptcha Provides a fluent interface
      */
     public function setSecretKey($secretKey)
     {
@@ -96,7 +96,7 @@ class ReCaptcha extends AbstractAdapter
      * Set ReCaptcha site key
      *
      * @param  string $siteKey
-     * @return ReCaptcha
+     * @return ReCaptcha Provides a fluent interface
      */
     public function setSiteKey($siteKey)
     {
@@ -130,7 +130,7 @@ class ReCaptcha extends AbstractAdapter
      * Set ReCaptcha secret key (BC version)
      *
      * @param  string $key
-     * @return ReCaptcha
+     * @return ReCaptcha Provides a fluent interface
      * @deprecated
      */
     public function setPrivKey($key)
@@ -142,7 +142,7 @@ class ReCaptcha extends AbstractAdapter
      * Set ReCaptcha site key (BC version)
      *
      * @param  string $key
-     * @return ReCaptcha
+     * @return ReCaptcha Provides a fluent interface
      * @deprecated
      */
     public function setPubKey($key)
@@ -187,7 +187,7 @@ class ReCaptcha extends AbstractAdapter
      * Set service object
      *
      * @param  ReCaptchaService $service
-     * @return ReCaptcha
+     * @return ReCaptcha Provides a fluent interface
      */
     public function setService(ReCaptchaService $service)
     {
@@ -213,7 +213,7 @@ class ReCaptcha extends AbstractAdapter
      *
      * @param  string $key
      * @param  mixed $value
-     * @return ReCaptcha
+     * @return ReCaptcha Provides a fluent interface
      */
     public function setOption($key, $value)
     {


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of class names and self keyword from the DocBlocks
