### PR TITLE
Support validation when value contains response

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
              include_path or via Composer. -->
         <env name="TESTS_ZEND_CAPTCHA_RECAPTCHA_SUPPORT" value="false" />
         <!-- Change these if you want to use your own keys -->
+        <!-- These are test keys. See: https://developers.google.com/recaptcha/docs/faq -->
         <env name="TESTS_ZEND_SERVICE_RECAPTCHA_SITE_KEY" value="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"/>
         <env name="TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY" value="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"/>
         <env name="TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE" value="03AI-r6f4PlCfbU_-3HGwscafLbnxjinCf7GKEErJlUHDVF1uJ_SoVebG8gJewkGjNTwLxMZNQPJ4XRTvovB8J6vHLHCVZ1yV_KzJc1Mca6QVZ_6MsNJxYsXa-5NUWTHRvl7XGkju_oPTlxRNDC7DPPkd3eaav0HW1SfdJY1uRd_w5Fkin7KBXz-Eg8oQRSRQ-MplJacQQ3rlKkpEssu1seliTNNidAmuuHWksZwdVAi4ZMyT52BA98_KitLVipT7yiqSka2m8oJZMa9uYb2buNR7X3qnqsJfUc9BxT5lF2HLiX79STktdSAI"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,10 @@
         <!-- Enable this if you have installed ZendService\ReCaptcha on the
              include_path or via Composer. -->
         <env name="TESTS_ZEND_CAPTCHA_RECAPTCHA_SUPPORT" value="false" />
+        <!-- Change these if you want to use your own keys -->
+        <env name="TESTS_ZEND_SERVICE_RECAPTCHA_SITE_KEY" value="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"/>
+        <env name="TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY" value="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"/>
+        <env name="TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE" value="03AI-r6f4PlCfbU_-3HGwscafLbnxjinCf7GKEErJlUHDVF1uJ_SoVebG8gJewkGjNTwLxMZNQPJ4XRTvovB8J6vHLHCVZ1yV_KzJc1Mca6QVZ_6MsNJxYsXa-5NUWTHRvl7XGkju_oPTlxRNDC7DPPkd3eaav0HW1SfdJY1uRd_w5Fkin7KBXz-Eg8oQRSRQ-MplJacQQ3rlKkpEssu1seliTNNidAmuuHWksZwdVAi4ZMyT52BA98_KitLVipT7yiqSka2m8oJZMa9uYb2buNR7X3qnqsJfUc9BxT5lF2HLiX79STktdSAI"/>
 
         <!-- Enable this to test GC operations. These often fail in parallel
              build environments. -->

--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -260,7 +260,7 @@ class ReCaptcha extends AbstractAdapter
         }
 
         $service = $this->getService();
-        if (array_key_exists($value, $context)) {
+        if ((is_string($value) || is_int($value)) && array_key_exists($value, $context)) {
             $res = $service->verify($context[$value]);
         } else {
             $res = $service->verify($value);

--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -260,8 +260,11 @@ class ReCaptcha extends AbstractAdapter
         }
 
         $service = $this->getService();
+        if (array_key_exists($value, $context)) {
+            $value = $context[$value];
+        }
 
-        $res = $service->verify($context[$value]);
+        $res = $service->verify($value);
         if (! $res) {
             $this->error(self::ERR_CAPTCHA);
             return false;

--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -261,10 +261,11 @@ class ReCaptcha extends AbstractAdapter
 
         $service = $this->getService();
         if (array_key_exists($value, $context)) {
-            $value = $context[$value];
+            $res = $service->verify($context[$value]);
+        } else {
+            $res = $service->verify($value);
         }
 
-        $res = $service->verify($value);
         if (! $res) {
             $this->error(self::ERR_CAPTCHA);
             return false;

--- a/test/ReCaptchaTest.php
+++ b/test/ReCaptchaTest.php
@@ -28,14 +28,6 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
         if (! getenv('TESTS_ZEND_CAPTCHA_RECAPTCHA_SUPPORT')) {
             $this->markTestSkipped('Enable TESTS_ZEND_CAPTCHA_RECAPTCHA_SUPPORT to test PDF render');
         }
-
-        if (isset($this->word)) {
-            unset($this->word);
-        }
-
-        $this->captcha = new ReCaptcha([
-            'sessionClass' => 'ZendTest\Captcha\TestAsset\SessionContainer'
-        ]);
     }
 
     public function testConstructorShouldSetOptions()
@@ -162,5 +154,35 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
     {
         $captcha = new ReCaptcha;
         $this->assertEquals('captcha/recaptcha', $captcha->getHelperName());
+    }
+
+    public function testValidationForDifferentElementName()
+    {
+        $captcha = new ReCaptcha([
+            'site_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SITE_KEY'),
+            'secret_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY'),
+        ]);
+        $captcha->getService()->setIp('127.0.0.1');
+
+        $response = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
+        $value = 'g-recaptcha-response';
+        $context = ['g-recaptcha-response' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE')];
+
+        $this->assertTrue($captcha->isValid($value, $context));
+    }
+
+    public function testValidationForResponseElementName()
+    {
+        $captcha = new ReCaptcha([
+            'site_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SITE_KEY'),
+            'secret_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY'),
+        ]);
+        $captcha->getService()->setIp('127.0.0.1');
+
+        $response = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
+        $value = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
+        $context = ['g-recaptcha-response' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE')];
+
+        $this->assertTrue($captcha->isValid($value, $context));
     }
 }

--- a/test/ReCaptchaTest.php
+++ b/test/ReCaptchaTest.php
@@ -190,6 +190,9 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($captcha->isValid($value, $context));
     }
 
+    /**
+     * @return HttpClient
+     */
     private function getHttpClient()
     {
         $socket = new Socket();

--- a/test/ReCaptchaTest.php
+++ b/test/ReCaptchaTest.php
@@ -28,7 +28,7 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         if (! getenv('TESTS_ZEND_CAPTCHA_RECAPTCHA_SUPPORT')) {
-            $this->markTestSkipped('Enable TESTS_ZEND_CAPTCHA_RECAPTCHA_SUPPORT to test PDF render');
+            $this->markTestSkipped('Enable TESTS_ZEND_CAPTCHA_RECAPTCHA_SUPPORT to test Recaptcha');
         }
     }
 

--- a/test/ReCaptchaTest.php
+++ b/test/ReCaptchaTest.php
@@ -164,8 +164,9 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
             'site_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SITE_KEY'),
             'secret_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY'),
         ]);
-        $captcha->getService()->setIp('127.0.0.1');
-        $captcha->getService()->setHttpClient($this->getHttpClient());
+        $service = $captcha->getService();
+        $service->setIp('127.0.0.1');
+        $service->setHttpClient($this->getHttpClient());
 
         $response = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
         $value = 'g-recaptcha-response';
@@ -180,8 +181,9 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
             'site_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SITE_KEY'),
             'secret_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY'),
         ]);
-        $captcha->getService()->setIp('127.0.0.1');
-        $captcha->getService()->setHttpClient($this->getHttpClient());
+        $service = $captcha->getService();
+        $service->setIp('127.0.0.1');
+        $service->setHttpClient($this->getHttpClient());
 
         $response = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
         $value = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');

--- a/test/ReCaptchaTest.php
+++ b/test/ReCaptchaTest.php
@@ -10,6 +10,8 @@
 namespace ZendTest\Captcha;
 
 use Zend\Captcha\ReCaptcha;
+use Zend\Http\Client as HttpClient;
+use Zend\Http\Client\Adapter\Socket;
 use ZendService\ReCaptcha\ReCaptcha as ReCaptchaService;
 
 /**
@@ -163,6 +165,7 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
             'secret_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY'),
         ]);
         $captcha->getService()->setIp('127.0.0.1');
+        $captcha->getService()->setHttpClient($this->getHttpClient());
 
         $response = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
         $value = 'g-recaptcha-response';
@@ -178,11 +181,23 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
             'secret_key' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_SECRET_KEY'),
         ]);
         $captcha->getService()->setIp('127.0.0.1');
+        $captcha->getService()->setHttpClient($this->getHttpClient());
 
         $response = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
         $value = getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE');
         $context = ['g-recaptcha-response' => getenv('TESTS_ZEND_SERVICE_RECAPTCHA_RESPONSE')];
 
         $this->assertTrue($captcha->isValid($value, $context));
+    }
+
+    private function getHttpClient()
+    {
+        $socket = new Socket();
+        $socket->setOptions([
+            'ssltransport' => 'tls',
+        ]);
+        return new HttpClient(null, [
+            'adapter' => $socket,
+        ]);
     }
 }


### PR DESCRIPTION
If the user passes in the response value directly to isValid(), e.g. by taking the `g-recaptcha-response` value directly, then this should work!

Fixes #30